### PR TITLE
Add concentration-QT worked example to vignette

### DIFF
--- a/vignettes/nlmixrFormula.Rmd
+++ b/vignettes/nlmixrFormula.Rmd
@@ -258,6 +258,143 @@ nlmixr(
 )
 ```
 
+## Worked example: concentration-QT analysis
+
+A common use of the formula interface is a thorough QT (TQT) or
+concentration-QT (C-QT) analysis. The clinical question is whether a 10 msec
+$\Delta QT$ is exceeded at therapeutic drug concentrations. The standard
+model has:
+
+- A categorical effect for nominal post-dose time (captures circadian and
+  food-related drift)
+- A continuous linear effect for drug concentration (the parameter of
+  interest)
+- A per-subject random intercept (baseline $\Delta QT$ offset)
+
+In the formula interface this is one call:
+
+```
+dQT ~ b + bRe ~ (bRe|id)
+param  = list(b ~ timeF + conc)
+```
+
+`b` is a single intercept parameter; `param` decomposes it into a fixed
+effect per `timeF` level *plus* a linear slope on `conc`. The random per-
+subject offset `bRe` is added to `b` in the predictor.
+
+### Simulating the data
+
+We start from a one-compartment oral PK profile (Bateman equation), scale it
+so the typical $C_{max}$ is about 1000 ng/mL, and apply per-subject
+log-normal scaling so individual $C_{max}$ values are log-normally
+distributed.
+
+```{r cqt-data-gen, class.source = 'fold-show'}
+withr::with_seed(42, {
+  nSubj    <- 40
+  nomTimes <- c(0, 0.5, 1, 1.5, 2, 3, 4, 6, 8, 12)  # 10 nominal times
+
+  # Typical 1-compartment oral PK profile (unit Bateman), then scaled
+  # so the population Cmax is 1000 ng/mL
+  bateman    <- function(t, ka = 2, ke = 0.1) {
+    (ka / (ka - ke)) * (exp(-ke * t) - exp(-ka * t))
+  }
+  cmaxFactor <- 1000 / max(bateman(seq(0, 12, 0.01)))
+
+  # Per-subject log-normal scaling of the concentration profile
+  subjScale  <- exp(rnorm(nSubj, mean = 0, sd = 0.4))
+
+  cqtDesign <-
+    expand.grid(id = 1:nSubj, time_h = nomTimes)
+  cqtDesign$conc  <- bateman(cqtDesign$time_h) * cmaxFactor *
+                     subjScale[cqtDesign$id]
+  cqtDesign$timeF <- factor(cqtDesign$time_h,
+                            levels = as.character(nomTimes))
+  cqtDesign$dQT   <- 1  # placeholder; nlmixrFormula(est="rxSolve") fills it in
+})
+```
+
+Now we simulate `dQT` from the true model. The true slope is 0.01
+msec/(ng/mL), which produces about a 10 msec $\Delta QT$ at the population
+$C_{max}$. The categorical time effects encode a typical circadian drift
+pattern. The simulation's `bRe` SD is 1 (the formula interface's current
+default for random-effect starting values).
+
+```{r cqt-sim, class.source = 'fold-show'}
+cqtSimPrep <-
+  nlmixrFormula(
+    dQT ~ b + bRe ~ (bRe|id),
+    data  = cqtDesign,
+    # 10 time-level intercepts (relative to time 0) + slope on conc
+    start = list(
+      b     = c(0,         # timeF == 0  (pre-dose baseline)
+                3, 5, 6, 5, 2, 0, -1, -2, -3,  # post-dose time effects
+                0.01),     # slope on conc (msec per ng/mL)
+      addSd = 3
+    ),
+    param = list(b ~ timeF + conc),
+    est   = "rxSolve"
+  )
+
+cqtData <-
+  cqtSimPrep |>
+  as.data.frame() |>
+  select(id, conc, timeF, dQT = sim)
+
+ggplot(cqtData, aes(x = conc, y = dQT, colour = timeF)) +
+  geom_point(alpha = 0.7) +
+  labs(x = "Concentration (ng/mL)", y = expression(Delta * "QT (msec)"))
+```
+
+### Fitting the model
+
+Algebraic models with both a factor and a continuous covariate on the same
+parameter can be hard for `focei`'s gradient calculation when there are
+many factor levels. A robust two-stage strategy is to fit the fixed effects
+with `bobyqa` (which is gradient-free and converges fast for this class of
+model) and then refine with `focei` using the bobyqa estimates as starts,
+which adds the random effect.
+
+```{r cqt-fit-fe, class.source = 'fold-show'}
+fitFE <-
+  nlmixr(
+    dQT ~ b,                                       # fixed effects only
+    data  = cqtData,
+    start = list(
+      b     = c(0, 3, 5, 6, 5, 2, 0, -1, -2, -3, 0.01),
+      addSd = 3
+    ),
+    param = list(b ~ timeF + conc),
+    est   = "bobyqa"
+  )
+
+fitFE
+```
+
+```{r cqt-fit-re, class.source = 'fold-show'}
+# Carry the bobyqa estimates forward as starts for focei + random effects
+feEst <- setNames(fitFE$iniDf$est, fitFE$iniDf$name)
+
+fitRE <-
+  nlmixr(
+    dQT ~ b + bRe ~ (bRe|id),
+    data  = cqtData,
+    start = list(
+      b     = c(feEst[1:10], feEst[["cov_conc_b"]]),
+      addSd = feEst[["addSd"]]
+    ),
+    param = list(b ~ timeF + conc),
+    est   = "focei"
+  )
+
+fitRE
+```
+
+The recovered `cov_conc_b` estimates the slope of concentration on
+$\Delta QT$. Multiplying by the population $C_{max}$ (about 1000 ng/mL)
+gives the projected $\Delta QT$ at $C_{max}$ — typically within ~1 msec of
+the simulated 10 msec.
+
 # Defining the model equation (the formula)
 
 The model formula has 3 parts: the dependent variable, the equation predicting


### PR DESCRIPTION
A worked example based on a TQT / C-QT analysis: 40 subjects, 10 nominal post-dose times treated as a categorical factor, and drug concentrations drawn from a 1-compartment Bateman profile with per-subject log-normal scaling (mean Cmax ~ 1000 ng/mL). The true conc-QT slope is 0.01 msec per ng/mL, producing the canonical ~10 msec dQT at Cmax.

The example demonstrates the mixed factor + continuous `param`:

  param = list(b ~ timeF + conc)

with the per-subject random intercept layered on via `(bRe|id)`. To work around the focei gradient-zero issue on factor-level covariate parameters, the example fits in two stages: bobyqa for the fixed effects to lock in time and conc estimates, then focei using those values as starts to add bRe.