### PR TITLE
Fix bootstrapFit() crash for single-parameter / single-eta models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # nlmixr2extra 5.1.0
 
+- `bootstrapFit()` now works for models with a single estimated
+  population parameter or a single random effect.  Previously the
+  confidence-interval quantile arrays in the bootstrap summary collapsed
+  to vectors in these cases, causing `bootstrapFit()` to error with
+  `dim(X) must have a positive length` or `incorrect number of
+  dimensions`.
+
 - Add focei/foce linearization
 
 - Add formula interface

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,13 @@
 # nlmixr2extra 5.1.0
 
 - `bootstrapFit()` now works for models with a single estimated
-  population parameter or a single random effect.  Previously the
-  confidence-interval quantile arrays in the bootstrap summary collapsed
-  to vectors in these cases, causing `bootstrapFit()` to error with
-  `dim(X) must have a positive length` or `incorrect number of
-  dimensions`.
+  population parameter, a single random effect, or no random effects at
+  all.  Previously the bootstrap summary collapsed 1-row / 1x1 quantile
+  arrays to vectors (and could not summarize a `NULL` omega), causing
+  `bootstrapFit()` to error with `dim(X) must have a positive length`,
+  `incorrect number of dimensions`, or `'data' must be of a vector type,
+  was 'NULL'`.  Printing the bootstrap summary of a model with no random
+  effects no longer errors either.
 
 - Add focei/foce linearization
 

--- a/R/computingutil.R
+++ b/R/computingutil.R
@@ -610,7 +610,8 @@ bootstrapFit <- function(fit,
   if (length(.nm) == 0) {
     stop("No parameters to update covariance matrix", call.=FALSE)
   }
-  .cov <- fit$bootSummary$omega$covMatrixCombined[.nm, .nm]
+  # drop = FALSE so a single retained parameter stays a 1x1 matrix for setCov()
+  .cov <- fit$bootSummary$omega$covMatrixCombined[.nm, .nm, drop = FALSE]
   .setCov(fit, covMethod = .cov)
   assign("covMethod", paste0("boot", fit$bootSummary$nboot), fit$env)
   invisible(fit)
@@ -1145,6 +1146,29 @@ extractVars <- function(fitlist, id = "method") {
   matrix(quants[k, , ], nrow = nrow(template), dimnames = dimnames(template))
 }
 
+#' Correlation matrix from a bootstrap covariance matrix
+#'
+#' Wraps `cov2cor()` but tolerates zero-variance entries (a parameter that did
+#' not vary across the bootstrap) and stores the standard deviations on the
+#' diagonal, matching the convention used by the bootstrap omega summary.
+#'
+#' @param covMatrix a covariance matrix
+#' @return a correlation matrix with the standard deviations on the diagonal
+#' @noRd
+.bootstrapCombinedCor <- function(covMatrix) {
+  w <- which(diag(covMatrix) == 0)
+  if (length(w) > 0) {
+    d <- dim(covMatrix)[1]
+    corMatrix <- matrix(0, d, d)
+    corMatrix[-w, -w] <- cov2cor(covMatrix[-w, -w])
+  } else {
+    corMatrix <- cov2cor(covMatrix)
+  }
+  diag(corMatrix) <- sqrt(diag(covMatrix))
+  dimnames(corMatrix) <- dimnames(covMatrix)
+  corMatrix
+}
+
 #' Summarize the bootstrapped fits/models
 #'
 #' @param fitList a list of lists containing information on the multiple bootstrapped models; similar to the output of modelsBootstrap() function
@@ -1180,6 +1204,29 @@ getBootstrapSummary <- function(fitList,
     if (id == "omega") {
       # omega estimates
       omegaMatlist <- extractVars(fitList, id)
+      if (is.null(omegaMatlist[[1]]) || nrow(omegaMatlist[[1]]) == 0L) {
+        # A model with no random effects has no omega to summarize.  Build the
+        # combined covariance from the fixed-effect bootstrap estimates alone so
+        # that bootstrapFit() can still update the covariance matrix.
+        parFixedlist <- extractVars(fitList, id = "parFixedDf")
+        parFixedlistVec <- do.call("rbind", lapply(parFixedlist, function(x) {
+          ret <- x$Estimate
+          if (is.null(names(ret))) {
+            ret <- stats::setNames(ret, rownames(x))
+          }
+          ret
+        }))
+        covMatrix <- cov(parFixedlistVec)
+        return(list(
+          mean = omegaMatlist[[1]],
+          median = omegaMatlist[[1]],
+          stdDev = omegaMatlist[[1]],
+          confLower = omegaMatlist[[1]],
+          confUpper = omegaMatlist[[1]],
+          covMatrixCombined = covMatrix,
+          corMatrixCombined = .bootstrapCombinedCor(covMatrix)
+        ))
+      }
       # simplify2array() collapses a list of 1x1 omega matrices (a single
       # random effect) into a plain vector, which breaks the apply(, 1:2, )
       # calls below; build the nEta x nEta x nboot array explicitly so a
@@ -1253,22 +1300,14 @@ getBootstrapSummary <- function(fitList,
       .w <- which(vapply(namesList, function(x) {
         !all(omgVecBoot[, x] == 0)
       }, logical(1), USE.NAMES=FALSE))
-      omgVecBoot <- omgVecBoot[, .w]
+      # drop = FALSE so a single retained omega entry stays a 1-column matrix
+      omgVecBoot <- omgVecBoot[, .w, drop = FALSE]
 
 
       parFixedOmegaCombined <- cbind(parFixedlistVec, omgVecBoot)
 
       covMatrix <- cov(parFixedOmegaCombined)
-      w <- which(diag(covMatrix) == 0)
-      if (length(w) > 0) {
-        d <- dim(covMatrix)[1]
-        corMatrix <- matrix(0, d, d)
-        corMatrix[-w, -w] <- cov2cor(covMatrix[-w, -w])
-      } else {
-        corMatrix <- cov2cor(covMatrix)
-      }
-      diag(corMatrix) <- sqrt(diag(covMatrix))
-      dimnames(corMatrix) <- dimnames(covMatrix)
+      corMatrix <- .bootstrapCombinedCor(covMatrix)
       lst <- list(
         mean = mn,
         median = median,
@@ -1359,6 +1398,10 @@ print.nlmixr2BoostrapSummary <- function(x, ..., sigdig = NULL) {
   ))
 
   lapply(seq_along(omega), function(x) {
+    # a model with no random effects has empty (NULL) omega summaries; skip them
+    if (is.null(omega[[x]]) || length(omega[[x]]) == 0L) {
+      return(invisible())
+    }
     cli::cli_text(cli::col_green(paste0("$", names(omega)[x])))
     print(signif(omega[[x]], sigdig))
   })

--- a/R/computingutil.R
+++ b/R/computingutil.R
@@ -1127,6 +1127,24 @@ extractVars <- function(fitlist, id = "method") {
   }
 }
 
+#' Reshape a quantile-array slice into a parameter-by-bound matrix
+#'
+#' `apply(x, 1:2, quantile)` returns an array with dimensions
+#' `nQuantLevel x nPar x nBound`.  Selecting one quantile level with
+#' `quants[k, , ]` collapses to a vector when there is a single parameter
+#' (`nPar == 1`), which then breaks the 2-D subscripting in [bootstrapFit()].
+#' Force the slice back to the intended matrix, taking the row count and
+#' dimnames from `template` (the matching matrix of bootstrap means).
+#'
+#' @param quants 3-D array produced by `apply(..., 1:2, quantile)`
+#' @param k quantile-level index selecting the first dimension
+#' @param template matrix with the desired final shape and dimnames
+#' @return a matrix with the same dimensions as `template`
+#' @noRd
+.bootstrapQuantSlice <- function(quants, k, template) {
+  matrix(quants[k, , ], nrow = nrow(template), dimnames = dimnames(template))
+}
+
 #' Summarize the bootstrapped fits/models
 #'
 #' @param fitList a list of lists containing information on the multiple bootstrapped models; similar to the output of modelsBootstrap() function
@@ -1162,16 +1180,26 @@ getBootstrapSummary <- function(fitList,
     if (id == "omega") {
       # omega estimates
       omegaMatlist <- extractVars(fitList, id)
-      varVec <- simplify2array(omegaMatlist)
+      # simplify2array() collapses a list of 1x1 omega matrices (a single
+      # random effect) into a plain vector, which breaks the apply(, 1:2, )
+      # calls below; build the nEta x nEta x nboot array explicitly so a
+      # single-eta model is handled the same as the multi-eta case.
+      .nEta <- nrow(omegaMatlist[[1]])
+      varVec <- array(unlist(omegaMatlist),
+                      dim = c(.nEta, .nEta, length(omegaMatlist)),
+                      dimnames = list(rownames(omegaMatlist[[1]]),
+                                      colnames(omegaMatlist[[1]]), NULL))
       mn <- apply(varVec, 1:2, mean, na.rm=TRUE)
       sd <- apply(varVec, 1:2, sd, na.rm=TRUE)
 
       quants <- apply(varVec, 1:2, function(x) {
         unname(quantile(x, quantLevels, na.rm=TRUE))
       })
-      median <- quants[1, , ]
-      confLower <- quants[2, , ]
-      confUpper <- quants[3, , ]
+      # quants[k, , ] would drop to a vector for a single random effect; keep
+      # the nEta x nEta matrix shape (see .bootstrapQuantSlice)
+      median <- .bootstrapQuantSlice(quants, 1, mn)
+      confLower <- .bootstrapQuantSlice(quants, 2, mn)
+      confUpper <- .bootstrapQuantSlice(quants, 3, mn)
 
       if (stdErrType != "perc") {
         confLower <- mn + qnorm(quantLevels[[2]]) * sd
@@ -1264,9 +1292,12 @@ getBootstrapSummary <- function(fitList,
           unname(quantile(x, quantLevels, na.rm = TRUE))
         })
 
-      median <- quants[1, , ]
-      confLower <- quants[2, , ]
-      confUpper <- quants[3, , ]
+      # quants[k, , ] would drop to a vector for a model with a single
+      # population parameter; keep the nPar x 2 matrix shape so the downstream
+      # subscripting in bootstrapFit() works (see .bootstrapQuantSlice)
+      median <- .bootstrapQuantSlice(quants, 1, mn)
+      confLower <- .bootstrapQuantSlice(quants, 2, mn)
+      confUpper <- .bootstrapQuantSlice(quants, 3, mn)
 
       if (stdErrType != "perc") {
         confLower <- mn + qnorm(quantLevels[[2]]) * sd

--- a/R/setCov.R
+++ b/R/setCov.R
@@ -78,7 +78,13 @@
     }
     .dat <- nlme::getData(obj)
     .ui <- obj$ui
-    .mat <- as.matrix(nlme::random.effects(obj)[, -1])
+    .re <- nlme::random.effects(obj)
+    if (is.null(.re)) {
+      # a model with no random effects has no individual eta matrix
+      .mat <- NULL
+    } else {
+      .mat <- as.matrix(.re[, -1])
+    }
     .control$skipCov <- obj$skipCov
     .control$etaMat <- .mat
     .fit2 <- nlmixr2est::nlmixr2CreateOutputFromUi(.ui, data=.dat, control=.control,

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -196,4 +196,64 @@ withr::with_tempdir({
       paste0("nlmixr2BootstrapCache_", "fit", "_", fit$bootstrapMd5)
     unlink(output_dir, recursive = TRUE, force = TRUE)
   })
+
+  test_that("bootstrapFit handles a single estimated population parameter", {
+    skip_on_cran()
+    # A model with one estimated population parameter (a single theta row in
+    # parFixedDf) and a single random effect (a 1x1 omega).  Both cases made
+    # the 3-D quantile array in getBootstrapSummary() collapse to a vector when
+    # sliced (quants[k, , ]), so bootstrapFit() crashed with
+    # "dim(X) must have a positive length" (omega branch) /
+    # "incorrect number of dimensions" (parFixedDf branch).
+    one.par <- function() {
+      ini({
+        tcl <- 1 ; label("Log Cl")
+        eta.cl ~ 0.3
+      })
+      model({
+        ka <- exp(0.45)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(3.45)
+        addSd <- 0.7
+        linCmt() ~ add(addSd)
+      })
+    }
+    suppressMessages(suppressWarnings(
+      fit <-
+        nlmixr(
+          one.par,
+          nlmixr2data::theo_sd,
+          est = "focei",
+          control = list(print = 0, eval.max = 10)
+        )
+    ))
+    # confirm the reprex really is the single-parameter / single-eta case
+    expect_equal(nrow(fit$parFixedDf), 1L)
+    expect_equal(dim(fit$omega), c(1L, 1L))
+
+    # bootstrapFit() used to error here; it must now run to completion
+    suppressMessages(suppressWarnings(
+      expect_error(
+        fitB <- nlmixr2extra:::bootstrapFit(fit, nboot = 5, restart = TRUE),
+        NA
+      )
+    ))
+
+    # the quantile slices must keep their matrix shape, not collapse to vectors
+    bootSummary <- fitB$bootSummary
+    expect_equal(dim(bootSummary$parFixedDf$median), c(1L, 2L))
+    expect_equal(dim(bootSummary$parFixedDf$confLower), c(1L, 2L))
+    expect_equal(dim(bootSummary$parFixedDf$confUpper), c(1L, 2L))
+    expect_equal(dim(bootSummary$omega$median), c(1L, 1L))
+    expect_equal(dim(bootSummary$omega$confLower), c(1L, 1L))
+    expect_equal(dim(bootSummary$omega$confUpper), c(1L, 1L))
+
+    # the bootstrap covariance should have been stored on the fit
+    expect_equal(fitB$env$covMethod, "boot5")
+
+    lapply(
+      list.files("./", pattern = "nlmixr2BootstrapCache_.*"),
+      function(x) unlink(x, recursive = TRUE, force = TRUE)
+    )
+  })
 })

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -256,4 +256,65 @@ withr::with_tempdir({
       function(x) unlink(x, recursive = TRUE, force = TRUE)
     )
   })
+
+  test_that("bootstrapFit handles a model with no random effects", {
+    skip_on_cran()
+    # A fixed-effects-only model: fit$omega is NULL.  The bootstrap omega
+    # summary has nothing to aggregate and the combined covariance must be built
+    # from the fixed effects alone; previously bootstrapFit() errored
+    # ("dim(X) must have a positive length" / "'data' must be of a vector type,
+    # was 'NULL'").  Printing the summary (with its empty omega entries) also
+    # used to error in print.nlmixr2BoostrapSummary().
+    no.eta <- function() {
+      ini({
+        tcl <- 1 ; label("Log Cl")
+        addSd <- 0.7
+      })
+      model({
+        ka <- exp(0.45)
+        cl <- exp(tcl)
+        v <- exp(3.45)
+        linCmt() ~ add(addSd)
+      })
+    }
+    suppressMessages(suppressWarnings(
+      fit <-
+        nlmixr(
+          no.eta,
+          nlmixr2data::theo_sd,
+          est = "focei",
+          control = list(print = 0, eval.max = 10)
+        )
+    ))
+    # confirm the reprex really has no random effects
+    expect_true(is.null(fit$omega) || length(fit$omega) == 0L)
+
+    # bootstrapFit() used to error here; it must now run to completion
+    suppressMessages(suppressWarnings(
+      expect_error(
+        fitB <- nlmixr2extra:::bootstrapFit(fit, nboot = 5, restart = TRUE),
+        NA
+      )
+    ))
+
+    # there is no omega to summarize, but the combined covariance of the fixed
+    # effects must still be a named matrix so setCov() can use it
+    bootSummary <- fitB$bootSummary
+    expect_null(bootSummary$omega$mean)
+    expect_true(is.matrix(bootSummary$omega$covMatrixCombined))
+    expect_equal(dim(bootSummary$omega$covMatrixCombined), c(2L, 2L))
+    expect_equal(rownames(bootSummary$omega$covMatrixCombined), c("tcl", "addSd"))
+    expect_equal(fitB$env$covMethod, "boot5")
+
+    # the bootstrap summary (with empty omega entries) must print without error
+    expect_error(
+      suppressMessages(utils::capture.output(print(bootSummary))),
+      NA
+    )
+
+    lapply(
+      list.files("./", pattern = "nlmixr2BootstrapCache_.*"),
+      function(x) unlink(x, recursive = TRUE, force = TRUE)
+    )
+  })
 })


### PR DESCRIPTION
## Problem

`bootstrapFit()` crashes for several edge-case model shapes:

- **one estimated population parameter** (single-row `parFixedDf`)
- **a single random effect** (1×1 omega)
- **no random effects at all** (`fit$omega` is `NULL`)

`getBootstrapSummary()` builds 3-D quantile arrays (`quantile-level × parameter ×
bound`) and slices them with `quants[k, , ]`; with one parameter/eta the slice
collapses to a vector. The omega branch fails even earlier because
`simplify2array()` collapses a list of 1×1 matrices to a vector, and a `NULL`
omega cannot be summarized at all. Symptoms:
`dim(X) must have a positive length`, `incorrect number of dimensions`, or
`'data' must be of a vector type, was 'NULL'`. Printing the bootstrap summary of
a no-random-effect model also errored.

## Fix

- `R/computingutil.R`
  - Build the omega `nEta × nEta × nboot` array explicitly (no `simplify2array`
    collapse).
  - `.bootstrapQuantSlice()` reshapes each quantile slice back to a matrix (omega
    + parFixedDf branches).
  - No-random-effect models: early-return a summary with empty omega entries and
    a combined covariance built from the fixed effects alone.
  - `.bootstrapCombinedCor()` helper for the cov→cor step; `drop = FALSE` on the
    single-parameter cov extraction and the single-omega-column subset.
  - `print.nlmixr2BoostrapSummary()` skips empty (NULL) omega entries.
- `R/setCov.R` — guard `random.effects(obj)` being `NULL` for no-random-effect
  models.

## Tests

Two regression tests in `tests/testthat/test-bootstrap.R`:
- single theta + single eta, and
- fixed-effects-only (no eta, including printing the summary).

Both **error before** this change and **pass after**.

## Backward compatibility

The 2+-parameter / multi-eta path is unchanged: `getBootstrapSummary()` output is
byte-identical (`all.equal == TRUE`) for a 3-parameter / 3-eta model across all
`stdErrType` values. Full `test-bootstrap.R` passes.

> Note: this branch also adds `drop = FALSE` at the same cov sites the separate
> `defensive-drop-false` branch touches — complementary changes, trivial merge.