### PR TITLE
Rename linearization fallback from FOCE to FOCEp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # nlmixr2extra 5.1.0
 
-- Add focei/foce linearization
+- Add focei/focep linearization
 
 - Add formula interface
 

--- a/R/linearizefocei.R
+++ b/R/linearizefocei.R
@@ -97,7 +97,7 @@ renameCol <- function(df, new, old){
 
 #' Generate a Linearization Model From Previous Fit
 #' @param ui rx model or fit object.
-#' @param focei boolean. If TRUE, use FOCEI linearization with individual and residual linearization. Default is TRUE.
+#' @param focei boolean. If TRUE, use FOCEI linearization with individual and residual linearization. If FALSE, use FOCEp linearization where the residual interaction linearization is skipped. Default is TRUE.
 #' @param derivFct boolean. If TRUE, use normalization derivative factors. Default is FALSE.
 #' @return rxUi model
 #' @author Omar I. Elashkar
@@ -203,7 +203,7 @@ linModGen <- function(ui, focei = TRUE, derivFct = FALSE){
 #' @param fit fit of nonlinear model fitted using any method with at least one eta. See details.
 #' @param mceta a numeric vector for mceta to try. See details.
 #' @param relTol relative deviation tolerance between original and linearized models objective functions. Used for switching if focei = NA. See details.
-#' @param focei Default is NA for automatic switch from FOCEI to FOCE if failed. See details.
+#' @param focei Default is NA for automatic switch from FOCEI to FOCEp if failed. See details.
 #' @param addEtas boolean. If TRUE, add etas on every theta and fix it to small value to get derivatives. Default is FALSE.
 #' @param derivFct boolean. If TRUE, turn on derivatives for linearization. Default is FALSE.
 #' @param plot boolean. Print plot of linearized vs original
@@ -217,9 +217,9 @@ linModGen <- function(ui, focei = TRUE, derivFct = FALSE){
 #' Escalating to next mceta will depend on the relative deviation `relTol` of the original and linearized models objective functions.
 #'
 #' If `focei` is set to `NA`, the function will first try to linearize using FOCEI.
-#' If the relative deviation between original and linearized models objective functions is greater than `relTol`, it will switch to FOCE where residual linearization is skipped.
+#' If the relative deviation between original and linearized models objective functions is greater than `relTol`, it will switch to FOCEp where residual linearization is skipped.
 #' If `focei` is set to `TRUE`, the function will use FOCEI linearization with individual and residual linearization.
-#' If `focei` is set to `FALSE`, the function will use FOCE linearization with residual interaction linearization skipped.
+#' If `focei` is set to `FALSE`, the function will use FOCEp linearization with residual interaction linearization skipped.
 #'
 #' If `derivFct` is set to `TRUE`, the function will use an extra factor for linearization that might help in stabilization.
 #' This might be useful to try with FOCEI.
@@ -288,7 +288,7 @@ linearize <- function(fit, mceta=c(-1, 10, 100, 1000), relTol=0.25, focei = NA, 
         cli::cli_alert_info("Linearization evaluation matched. Linearization might be feasible ...")
     } else{
         cli::cli_alert_warning("Linearization evaluation mismatched by deltaOFV > {relTol}. Linearization might be difficult")
-        cli::cli_alert_warning("Switching to linearization around predictions only (Variance interaction linearization skipped)")
+        cli::cli_alert_warning("Switching to FOCEp linearization around predictions only (Variance interaction linearization skipped)")
         linMod <- linMod %>%  model(foceiLin <- 0)
         secondEval <- evalFun()
         cli::cli_alert_info("{secondEval$oObj} MAP:{secondEval$lObj_map}")
@@ -315,7 +315,7 @@ linearize <- function(fit, mceta=c(-1, 10, 100, 1000), relTol=0.25, focei = NA, 
                 cli::cli_alert_info(paste("Using mceta = ", mceta[i], "provided inadequate linearization. Trying mceta = ", mceta[i+1], "..."))
             } else{
                 if(is.na(focei) & !exists("secondEval")){ # final switch iteration (after estimation) 
-                    cli::cli_alert_info("Switching to FOCE after full FOCEI estimation failed ...")
+                    cli::cli_alert_info("Switching to FOCEp after full FOCEI estimation failed ...")
                     secondEval <- evalFun()
                     linMod <- linMod %>%  model(foceiLin <- 0)
                     fitL <- nlmixr(linMod, derv, est="focei",
@@ -326,7 +326,7 @@ linearize <- function(fit, mceta=c(-1, 10, 100, 1000), relTol=0.25, focei = NA, 
                     relDev <- abs((oObj-lObj)/lObj)
                     
                     if(relDev <=relTol){
-                        cli::cli_alert_danger("FOCE Linearization was inadequate for the given tolerance. Try increasing the tolerance, refine the model or fit with mceta")
+                        cli::cli_alert_danger("FOCEp Linearization was inadequate for the given tolerance. Try increasing the tolerance, refine the model or fit with mceta")
                     }
 
                 } else{
@@ -347,13 +347,13 @@ linearize <- function(fit, mceta=c(-1, 10, 100, 1000), relTol=0.25, focei = NA, 
     }
     m <- paste(
         "Linearization method: {
-              ifelse(is.na(focei), 'Auto', ifelse(focei, 'FOCE (individual + residual)', 'Variance interaction skipped'))
+              ifelse(is.na(focei), 'Auto', ifelse(focei, 'FOCEI (individual + residual)', 'FOCEp (variance interaction skipped)'))
               }
         Linearization Relative Tolerance: {relTol}
         {
           ifelse(is.na(focei) & exists('secondEval'), 
-            'Linearization method switched automatically to FOCE approximation (residuals interaction linearization ignored)', 
-              ifelse(is.na(focei) & !exists('secondEval'), 'FOCEI Linearization', ifelse(focei, 'FOCEI Linearization', 'FOCE Linearization')))
+            'Linearization method switched automatically to FOCEp approximation (residuals interaction linearization ignored)',
+              ifelse(is.na(focei) & !exists('secondEval'), 'FOCEI Linearization', ifelse(focei, 'FOCEI Linearization', 'FOCEp Linearization')))
           }
         {paste(finalEval$message, collapse = '')}
         Fitted Linear OFV: {lObj}

--- a/inst/iivSearch.R
+++ b/inst/iivSearch.R
@@ -139,13 +139,13 @@ ggplot(data.frame(rank = as.factor(unlist(lapply(res_fixed, \(x) x[["rank"]]))))
 
 ggplot(data.frame(rank = as.factor(unlist(lapply(res_fixed_foce, \(x) x[["rank"]]))))) + 
   geom_bar(aes(x = rank, y =  (..count..)/sum(..count..))) + 
-  labs(y = "Frequency", title = "FOCE Linearization", x = "True BSV Rank") + theme_classic()
+  labs(y = "Frequency", title = "FOCEp Linearization", x = "True BSV Rank") + theme_classic()
 
 
 data_cumulative <- data.frame(
     iteration = c(1:100, 1:100),
     rank = c(unlist(lapply(res_fixed_foce, \(x) x[["rank"]])), unlist(lapply(res_fixed, \(x) x[["rank"]]))),
-    method = sort(rep(c("FOCEI", "FOCE"), times = 100))
+    method = rep(c("FOCEp", "FOCEI"), each = 100)
   ) |> 
   arrange(method, rank) |>
   group_by(method) |>
@@ -154,7 +154,7 @@ data_cumulative <- data.frame(
 ggplot(data_cumulative, aes(fill = method, x = rank)) + 
   geom_bar(aes(y =  (..count..)/sum(..count..)))  + 
   labs(y = "Frequency", title = "True BSV Rank", x = "True BSV Rank") + 
-  scale_fill_manual(values = c("FOCEI" = "#D73027", "FOCE" = "#4575B4")) +
+  scale_fill_manual(values = c("FOCEI" = "#D73027", "FOCEp" = "#4575B4")) +
   facet_grid(~method)  + 
   theme_minimal() + 
   theme(legend.position = "none") + 
@@ -171,7 +171,7 @@ ggplot(data_cumulative, aes(x = rank, y = cumulative_fraction, color = method)) 
   theme(legend.position = "none") + 
   scale_x_continuous(breaks = 1:10) +
   geom_hline(yintercept=0.80, linetype = 3) + 
-  scale_color_manual(values = c("FOCEI" = "#D73027", "FOCE" = "#4575B4")) +
+  scale_color_manual(values = c("FOCEI" = "#D73027", "FOCEp" = "#4575B4")) +
   theme(legend.title = element_blank())
 
 

--- a/man/linModGen.Rd
+++ b/man/linModGen.Rd
@@ -9,7 +9,7 @@ linModGen(ui, focei = TRUE, derivFct = FALSE)
 \arguments{
 \item{ui}{rx model or fit object.}
 
-\item{focei}{boolean. If TRUE, use FOCEI linearization with individual and residual linearization. Default is TRUE.}
+\item{focei}{boolean. If TRUE, use FOCEI linearization with individual and residual linearization. If FALSE, use FOCEp linearization where the residual interaction linearization is skipped. Default is TRUE.}
 
 \item{derivFct}{boolean. If TRUE, use normalization derivative factors. Default is FALSE.}
 }

--- a/man/linearize.Rd
+++ b/man/linearize.Rd
@@ -22,7 +22,7 @@ linearize(
 
 \item{relTol}{relative deviation tolerance between original and linearized models objective functions. Used for switching if focei = NA. See details.}
 
-\item{focei}{Default is NA for automatic switch from FOCEI to FOCE if failed. See details.}
+\item{focei}{Default is NA for automatic switch from FOCEI to FOCEp if failed. See details.}
 
 \item{addEtas}{boolean. If TRUE, add etas on every theta and fix it to small value to get derivatives. Default is FALSE.}
 
@@ -45,9 +45,9 @@ The function accepts a fit object fitted using any method. However, if the metho
 Escalating to next mceta will depend on the relative deviation \code{relTol} of the original and linearized models objective functions.
 
 If \code{focei} is set to \code{NA}, the function will first try to linearize using FOCEI.
-If the relative deviation between original and linearized models objective functions is greater than \code{relTol}, it will switch to FOCE where residual linearization is skipped.
+If the relative deviation between original and linearized models objective functions is greater than \code{relTol}, it will switch to FOCEp where residual linearization is skipped.
 If \code{focei} is set to \code{TRUE}, the function will use FOCEI linearization with individual and residual linearization.
-If \code{focei} is set to \code{FALSE}, the function will use FOCE linearization with residual interaction linearization skipped.
+If \code{focei} is set to \code{FALSE}, the function will use FOCEp linearization with residual interaction linearization skipped.
 
 If \code{derivFct} is set to \code{TRUE}, the function will use an extra factor for linearization that might help in stabilization.
 This might be useful to try with FOCEI.

--- a/tests/testthat/test-linearizefocei.R
+++ b/tests/testthat/test-linearizefocei.R
@@ -426,7 +426,7 @@ test_that("Linearize multiple endpoints ", {
     # fit <- readRDS(system.file("warfarin.RDS", package="nlmixr2extra"))
 
     suppressWarnings(
-        # this will switch to FOCE even after successful evaluation. 
+        # this will switch to FOCEp even after successful evaluation.
         # The match was 4% for OFV, but mismatch for omega/eta
         # SAEM is better in next test. No switch and lower error
       {

--- a/vignettes/articles/model-linearization.Rmd
+++ b/vignettes/articles/model-linearization.Rmd
@@ -57,8 +57,10 @@ y_i \approx f_0 + \underbrace{\sum_k \frac{\partial f}{\partial\eta_k}\bigg|_{\h
 $$
 
 where $\varepsilon \sim \mathcal{N}(0,\,r_0^2)$ and the linearized residual
-variance is similarly expanded. This is the "FOCE approximation". Adding the
-residual-variance gradient gives the full "FOCEI approximation".
+variance is similarly expanded. This is the "FOCEp approximation" (FOCE
+without the eta/residual interaction, but keeping the live conditional
+residual variance). Adding the residual-variance gradient gives the full
+"FOCEI approximation".
 
 Because the linearized model is itself linear in the $\eta$ parameters, each
 candidate structure requires only **one fast FOCEI fit** rather than a full
@@ -188,23 +190,23 @@ linearizePlot(fitLin)
 The plot shows original vs. linearized individual objective values and etas.
 Points should lie on the identity line for a good approximation.
 
-## FOCE vs. FOCEI linearization
+## FOCEp vs. FOCEI linearization
 
 The `focei` argument controls whether the residual-variance gradient is
 included:
 
 | `focei` | Description |
 |---------|-------------|
-| `NA` (default) | Try FOCEI; switch to FOCE automatically if `relTol` is exceeded |
+| `NA` (default) | Try FOCEI; switch to FOCEp automatically if `relTol` is exceeded |
 | `TRUE`  | Always use FOCEI (individual + residual linearization) |
-| `FALSE` | Always use FOCE (residual interaction linearization skipped) |
+| `FALSE` | Always use FOCEp (residual interaction linearization skipped) |
 
 FOCEI is more accurate for models with heteroscedastic residuals (proportional
-or combined error). FOCE is faster and more stable for additive-only models.
+or combined error). FOCEp is faster and more stable for additive-only models.
 
 ```{r focei-opts, eval=FALSE}
-# Force FOCE linearization
-fitLinFoce <- linearize(fit, addEtas = TRUE, focei = FALSE)
+# Force FOCEp linearization
+fitLinFocep <- linearize(fit, addEtas = TRUE, focei = FALSE)
 
 # Force FOCEI
 fitLinFocei <- linearize(fit, addEtas = TRUE, focei = TRUE)
@@ -376,7 +378,7 @@ resRes$summary[order(resRes$summary$BIC), ]
 **Linearization fails to converge (`relTol` exceeded)**
 
 - Try larger `mceta` values: `mceta = c(100, 500, 2000)`.
-- Switch to `focei = FALSE` (FOCE) which is more numerically stable.
+- Switch to `focei = FALSE` (FOCEp) which is more numerically stable.
 - Increase `relTol` slightly (e.g. `0.30`) for a looser quality threshold.
 
 **`iivSearch` produces many `NA` entries**


### PR DESCRIPTION
## Summary

The `linearize()` fallback — used when FOCEI linearization exceeds `relTol` or when `focei = FALSE` — was documented and reported as "FOCE". What it actually does (skip the residual-variance interaction linearization via `foceiLin <- 0` while keeping the live conditional residual variance `r`) corresponds to nlmixr2est's `focep` (FOCE+) method, not the NONMEM-style frozen-R FOCE. This PR renames the fallback to FOCEp throughout the code base:

- **`R/linearizefocei.R`**: roxygen docs for `linearize()`/`linModGen()`, the "Switching to ..." cli messages, and the linearization summary labels. Also fixes the summary label for `focei = TRUE`, which was mislabeled `FOCE (individual + residual)` instead of FOCEI.
- **`man/linearize.Rd`, `man/linModGen.Rd`**: regenerated via `devtools::document()`.
- **`vignettes/articles/model-linearization.Rmd`**: theory section now calls the prediction-only expansion the "FOCEp approximation" (with a parenthetical defining it), and the `focei` option table / troubleshooting tips use FOCEp.
- **`inst/iivSearch.R`**: plot labels for the `focei = FALSE` runs renamed FOCE → FOCEp; the `sort()`-based method labeling was replaced with an explicit `rep(..., each = 100)` since "FOCEp" no longer sorts before "FOCEI" the way "FOCE" did.
- **`NEWS.md`**: 5.1.0 entry now reads "focei/focep linearization".
- **`tests/testthat/test-linearizefocei.R`**: comment updated.

No behavioral change to the estimation itself: the linearized model is still fit with `est = "focei"`; with `foceiLin <- 0` the linearized residual variance no longer depends on the etas, so the naming is the only thing that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)