### PR TITLE
Fix covarSearchAuto() covariate selection (#103)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # nlmixr2extra 5.1.0
 
+- Fix `covarSearchAuto()` crashing with "wrong arguments for subsetting
+  an environment" when a covariate is selected; the best model is now
+  re-fit to recover its fit object. Also corrected the forward inclusion
+  test, which had an inverted sign so improving covariates were never
+  selected (#103)
+
 - Add focei/foce linearization
 
 - Add formula interface

--- a/R/SCM.R
+++ b/R/SCM.R
@@ -240,13 +240,15 @@ forwardSearch <- function(varsVec,covarsVec,catvarsVec=NULL,fit, pVal = 0.05, ou
       nam_var <- strsplit(covNames,split='_', fixed=TRUE)[[1]][3]
       nam_covar <- strsplit(covNames,split='_', fixed=TRUE)[[1]][2]
 
-      # fwd: if deltObjf <0: pchisq=1-pchisq(-deltObjf, dof), else pchisq=1
+      # fwd: dObjf = base objf - candidate objf, so dObjf > 0 means adding the
+      #      covariate improved (lowered) the objective function. The likelihood
+      #      ratio statistic is the drop in objf (dObjf); test it against chisq.
       # bck: if deltObjf >0: pchisq=1-pchisq(deltObjf, dof), else pchisq=1
 
       dObjf <- fit$objf - x$objf
       dof <- length(x$finalUiEnv$ini$est) - length(fit$finalUiEnv$ini$est)
-      if (dObjf < 0) {
-        pchisqr <- 1 - pchisq(-dObjf, df = dof)
+      if (dObjf > 0) {
+        pchisqr <- 1 - pchisq(dObjf, df = dof)
       }
       else {
         pchisqr <- 1
@@ -274,7 +276,7 @@ forwardSearch <- function(varsVec,covarsVec,catvarsVec=NULL,fit, pVal = 0.05, ou
       print(bestRow)
 
       fit <-
-        covSearchRes[[which.min(resTable$pchisqr)]][[1]] # extract fit object corresponding to the best model
+        suppressWarnings(nlmixr2(covSearchRes[[which.min(resTable$pchisqr)]], data, fit$est)) # re-fit the best model to obtain its fit object
 
       covInfo[[paste0(as.character(bestRow$covar), as.character(bestRow$var))]] <- NULL
 
@@ -474,7 +476,7 @@ backwardSearch <- function(varsVec,covarsVec,catvarsVec=NULL, fitorig, fitupdate
       print(bestRow)
 
       fit <-
-        covSearchRes[[which.min(resTable$pchisqr)]][[1]] # extract fit object corresponding to the best model
+        suppressWarnings(nlmixr2(covSearchRes[[which.min(resTable$pchisqr)]], data, fit$est)) # re-fit the best model to obtain its fit object
       covInfo[[paste0(as.character(bestRow$covar), as.character(bestRow$var))]] <- NULL
 
       saveRDS(fit, file = paste0(outputDir, "/", "backward_", "step_", stepIdx, "_", "fit", "_", paste0(as.character(bestRow$covar), as.character(bestRow$var)), ".RData"))

--- a/tests/testthat/test-SCM-covarSearchAuto.R
+++ b/tests/testthat/test-SCM-covarSearchAuto.R
@@ -1,0 +1,106 @@
+skip_on_cran()
+
+# covarSearchAuto() covariate-selection fixes (Issue 103) ----
+
+# Two bugs were fixed here:
+#
+# 1. When a covariate passed the inclusion threshold, forwardSearch()/
+#    backwardSearch() tried to recover the best fit with
+#    `covSearchRes[[which.min(resTable$pchisqr)]][[1]]`. The elements of
+#    covSearchRes are model objects (rxUi/environments), not lists, so `[[1]]`
+#    raised "wrong arguments for subsetting an environment" and the search
+#    crashed. The best model is now re-fit to recover its fit object.
+#
+# 2. The forward inclusion test had an inverted sign: with
+#    `dObjf <- fit$objf - x$objf` an improving candidate has dObjf > 0, but the
+#    code computed a p-value only when dObjf < 0. As a result an improving
+#    covariate always received pchisqr == 1 and was never selected, while a
+#    worsening candidate was the one that got a p-value (and triggered bug 1).
+
+# Simulate a data set with a strong, well-scaled covariate effect on clearance
+# so that the covariate is unambiguously selected -- this exercises the re-fit
+# line that used to crash and the corrected forward inclusion test.
+simCovModel <- function() {
+  ini({
+    tka <- 0.45
+    tcl <- 1.0
+    tv <- 3.45
+    b.cl <- 0.5
+    eta.ka ~ 0.3
+    eta.cl ~ 0.02
+    eta.v ~ 0.05
+    add.sd <- 0.2
+  })
+  model({
+    ka <- exp(tka + eta.ka)
+    cl <- exp(tcl + b.cl * SCWT + eta.cl)
+    v <- exp(tv + eta.v)
+    linCmt() ~ add(add.sd)
+  })
+}
+
+makeCovData <- function() {
+  set.seed(3)
+  obsT <- seq(0.5, 60, length.out = 12)
+  ev <- do.call(rbind, lapply(seq_len(50), function(id) {
+    z <- round(stats::rnorm(1), 3)
+    e <- as.data.frame(rxode2::et(amt = 320) |> rxode2::et(obsT))
+    e$ID <- id
+    e$SCWT <- z
+    e
+  }))
+  s <- rxode2::rxSolve(simCovModel(), ev, returnType = "data.frame")
+  dose <- do.call(rbind, lapply(seq_len(50), function(id) {
+    data.frame(ID = id, time = 0, DV = NA, amt = 320, evid = 1,
+               SCWT = ev$SCWT[ev$ID == id][1])
+  }))
+  obs <- data.frame(ID = s$id, time = s$time, DV = s$sim, amt = NA, evid = 0,
+                    SCWT = s$SCWT)
+  d <- rbind(dose, obs)
+  d[order(d$ID, d$time, -d$evid), ]
+}
+
+baseCovModel <- function() {
+  ini({
+    tka <- 0.45
+    tcl <- 1.0
+    tv <- 3.45
+    eta.ka ~ 0.3
+    eta.cl ~ 0.1
+    eta.v ~ 0.1
+    add.sd <- 0.3
+  })
+  model({
+    ka <- exp(tka + eta.ka)
+    cl <- exp(tcl + eta.cl)
+    v <- exp(tv + eta.v)
+    linCmt() ~ add(add.sd)
+  })
+}
+
+test_that("covarSearchAuto completes and selects a real covariate (Issue 103)", {
+  d <- makeCovData()
+  fit <- suppressWarnings(
+    nlmixr2(baseCovModel(), d, est = "focei",
+            control = nlmixr2est::foceiControl(print = 0))
+  )
+
+  res <- suppressWarnings(
+    covarSearchAuto(fit, varsVec = c("cl", "v"), covarsVec = "SCWT",
+                    searchType = "forward", restart = TRUE)
+  )
+
+  # returns the documented structure ...
+  expect_true(is.list(res))
+  expect_true(all(c("summaryTable", "resFwd") %in% names(res)))
+
+  # ... the re-fit line recovered a genuine fit object (bug 1: no more
+  # "wrong arguments for subsetting an environment")
+  expect_s3_class(res$resFwd[[1]], "nlmixr2FitData")
+
+  # ... and the strong SCWT-on-cl effect was selected (bug 2: improving
+  # covariates are now included instead of always getting pchisqr == 1)
+  included <- res$summaryTable[res$summaryTable$included == "yes", ]
+  expect_true(nrow(included) >= 1)
+  expect_true(any(unlist(included$covar) == "SCWT" & unlist(included$var) == "cl"))
+})


### PR DESCRIPTION
Fixes #103.

## Summary

`covarSearchAuto()` crashed with **"wrong arguments for subsetting an environment"** as soon as a covariate passed the inclusion threshold, so the stepwise search could never complete. This PR fixes that crash and a related inverted-sign bug in the forward inclusion test.

## Fixes

**1. Crash: `covSearchRes[[...]][[1]]` (the reported bug)**

`forwardSearch()`/`backwardSearch()` recovered the best fit with `covSearchRes[[which.min(resTable$pchisqr)]][[1]]`, but the elements of `covSearchRes` are model objects (rxUi/environments), not lists, so `[[1]]` raised *"wrong arguments for subsetting an environment"*. The selected best model is now re-fit to recover its fit object.

**2. Inverted sign in the forward inclusion test**

With `dObjf <- fit$objf - x$objf`, an improving candidate has `dObjf > 0`, but the code only computed a p-value when `dObjf < 0`:

```r
if (dObjf < 0) { pchisqr <- 1 - pchisq(-dObjf, df = dof) } else { pchisqr <- 1 }
```

So improving covariates always received `pchisqr == 1` and were never selected, while a *worsening* candidate got the p-value (and was what triggered bug 1). Corrected to `if (dObjf > 0)`, matching the symmetric backward-search test.

## Test

Adds `tests/testthat/test-SCM-covarSearchAuto.R`, which runs `covarSearchAuto()` to completion on a model with a strong, well-scaled covariate effect and asserts (a) the search returns the documented structure with a real `nlmixr2FitData` fit object (regression for bug 1), and (b) the covariate is selected (regression for bug 2).

## Follow-up (not in this PR)

The issue's secondary observation — covariate effects estimated as ~0 under FOCEi — traces to a **separate nlmixr2est issue**, not covariate centering: FOCEi freezes a `theta` initialized at exactly 0 (parameter scaling by initial magnitude breaks at 0). Minimal reprex, with plain generic initial estimates:

```
b.init = 0     -> objf = -572.5,  b = -0.00019   (frozen at ~0)
b.init = 0.01  -> objf = -1343.6, b =  0.03109   (recovers the true effect)
```

SAEM recovers the effect correctly regardless. This is being pursued separately against nlmixr2est.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
